### PR TITLE
Repair warnings from deprecated Future API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["async"]
 
 byteorder = "1.0"
 capnp = "0.8"
-futures = "0.1.1"
+futures = "0.1.12"
 
 [dev-dependencies]
 capnp = { version = "0.8", features = ["quickcheck"] }

--- a/src/write_queue.rs
+++ b/src/write_queue.rs
@@ -205,7 +205,7 @@ impl <W, M> Future for WriteQueue<W, M> where W: io::Write, M: AsOutputSegments 
                 IntermediateState::WriteDone(m, w) => {
                     match ::std::mem::replace(&mut self.state, State::BetweenWrites(w)) {
                         State::Writing(_, complete) => {
-                            complete.send(m)
+                            complete.send(m).unwrap_or(());
                         }
                         _ => unreachable!(),
                     }
@@ -224,7 +224,7 @@ impl <W, M> Future for WriteQueue<W, M> where W: io::Write, M: AsOutputSegments 
                     match end_notifier {
                         None => (),
                         Some((result, complete)) => {
-                            complete.send(());
+                            complete.send(()).unwrap_or(());
                             if let Err(e) = result {
                                 return Err(e)
                             }


### PR DESCRIPTION
- Imports Future from its new home in futures::future
- In write_queue.r uses complete.send() attached to a blinding unwrap_or() to match the existing behaviour ("finish and ignore") with the new send() method, which has replaced complete().